### PR TITLE
Adding subproject search results pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,21 @@ before_install:
 - rm -rf dependencies
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/\/'$REPO_NAME'/g' ./_config.yml
+- sed -i 's/`search\.html`/`https\:\/\/docs\.netapp\.com\/us-en\/'$REPO_NAME'\/search\.html`/g' ./webpack/components/Search.js
 - ES_INDEX="clouddocs-"$REPO_NAME"-prod"
 - SK_INDEXES=$ES_INDEX
 - ES_INDEX_URL="https\:\/\/"$ES_AUTH"\@"$ES_API
 - SK_ES_URL="https\:\/\/"$ES_API$SK_INDEXES
 - sed -i 's/url\:\s*\"localhost\:9200\"/url\:\ \"'$ES_INDEX_URL'\"/g' ./_config.yml
 - sed -i 's/index\_name\:\s*.*/index\_name\:\ \"'$ES_INDEX'\"/g' ./_config.yml
+- cp -rl search.html ./cloud\_volumes\_ontap/search.html
+- sed -i 's/permalink\:\s*\/search\.html/permalink\:\ cloud\_volumes\_ontap\/search\.html/g' ./cloud\_volumes\_ontap/search.html
+- cp -rl search.html ./cloud\_volumes\_service/search.html
+- sed -i 's/permalink\:\s*\/search\.html/permalink\:\ cloud\_volumes\_service\/search\.html/g' ./cloud\_volumes\_service/search.html
+- cp -rl search.html ./genomics/search.html
+- sed -i 's/permalink\:\s*\/search\.html/permalink\:\ genomics\/search\.html/g' ./genomics/search.html
+- cp -rl search.html ./NPS/search.html
+- sed -i 's/permalink\:\s*\/search\.html/permalink\:\ NPS\/search\.html/g' ./NPS/search.html
 - sed -i 's/REPO\_URL/'$REPO_NAME'/g' ./webpack/components/Search.js
 - sed -i 's/ES\_AUTH/\"'$ES_AUTH'\"/g' ./webpack/components/Search.js
 - sed -i 's/SK\_ES\_URL/\"'$SK_ES_URL'\"/g' ./webpack/components/Search.js


### PR DESCRIPTION
To get around a subproject architecture limitation. This provides each endpoint with a search results page, with correct relative linking. 